### PR TITLE
Added support for rfm69hw

### DIFF
--- a/raspyrfm/rfm69.py
+++ b/raspyrfm/rfm69.py
@@ -122,6 +122,8 @@ RegAesKey1 = 0x3E
 RegTemp1 = 0x4E
 RegTemp2 = 0x4F
 RegTestLna = 0x58
+RegTestPa1 = 0x5A
+RegTestPa2 = 0x5C
 RegTestDagc = 0x6F
 RegTestAfc = 0x71
 
@@ -196,6 +198,7 @@ class Rfm69():
 		self.__fifothresh = 32
 		self.__packet_format = PacketFormat_Fixed
 		self.__aes_on = False
+                self.__isrfm69hw = False
 
 		print("RFM69 found on CS " + str(cs), file=sys.stderr)
 		GPIO.setmode(GPIO.BCM)
@@ -265,7 +268,8 @@ class Rfm69():
 
 		for key in config:
 			self.__write_reg(key, config[key])
-
+                
+                self.__set_highPower()
 		self.mode_standby()
 		print("Init complete.", file = sys.stderr)
 
@@ -293,9 +297,29 @@ class Rfm69():
 		dio *= 2
 		self.__set_reg(reg, 0xC0 >> dio, mapping << (6 - dio))
 
+        def __set_highPower(self):
+            #Must be called after initialization for rfm69hw
+            if(self.__isrfm69hw == True):
+                self.__write_reg(RegOcp, 0x0F) # OCP OFF
+                self.__write_reg(RegPaLevel, (self.read_reg(RegPaLevel) & 0x1F) | 0x60) #PA0 OFF PA1 ON  PA2 ON
+            else:
+                self.__write_reg(RegOcp, 0x1A) #OCP ON
+                self.__write_reg(RegPaLevel, (self.read_reg(RegPaLevel) & 0x1F) | 0x80) #PA0 ON  PA1 OFF PA2 OFF
+
+        def __set_highPowerRegs(self, mode):
+            #Registers only present in rfm69hw
+            if(self.__isrfm69hw):
+                if(mode == MODE_TX):
+                    self.__write_reg(RegTestPa1, 0x5D)
+                    self.__write_reg(RegTestPa2, 0x7C)
+                else:
+                    self.__write_reg(RegTestPa1, 0x55)
+                    self.__write_reg(RegTestPa2, 0x70)
+
 	def __set_mode(self, mode):
 		self.__write_reg(RegOpMode, mode << 2)
-		self.__mode = mode
+		self.__set_highPowerRegs(mode)
+                self.__mode = mode
 		while ((self.read_reg(RegIrqFlags1) & (1<<7)) == 0):
 			pass
 
@@ -333,7 +357,17 @@ class Rfm69():
 
 			elif key == "TxPower":
 				pwr = int(value + 18)
-				self.__write_reg(RegPaLevel, 0x80 | (pwr & 0x1F))
+                                if(self.__isrfm69hw == True):
+                                    self.__write_reg(RegPaLevel, 0x60 | (pwr & 0x1F))
+                                else:
+				    self.__write_reg(RegPaLevel, 0x80 | (pwr & 0x1F))
+
+                        elif key == "IsRFM69HW":
+                                self.__isrfm69hw = value
+                                if(value == True):
+                                    self.__write_reg(RegPaLevel, (self.read_reg(RegPaLevel) & 0x1F) | 0x60)
+                                else:
+                                    self.__write_reg(RegPaLevel, (self.read_reg(RegPaLevel) & 0x1F) | 0x80)
 
 			elif key == "Datarate":
 				rate = int(round(FXOSC / (value * 1000)))


### PR DESCRIPTION
Hi,

I just added a bit of TX power register handling to support RFM69HW/HCW modules as otherwise the high power modules do not start transmitting (they have more power amplifier stages). It is comparable to the "#define IS_RFM69HW" in https://github.com/LowPowerLab/RFM69. 

I tested it with the rcpuse app. My setup is basically the same as your hardware module but build from Adafruit RFM69HCW modules on breadboard. 

Best,
Kai Gemlau